### PR TITLE
Some default values were None

### DIFF
--- a/zabbix2jira/cli.py
+++ b/zabbix2jira/cli.py
@@ -17,15 +17,14 @@ Examples:
 
 Options:
     -i, --event-id=<id>     Unique event ID from Zabbix (tracking)
-    -t, --issue-type=<type> Issue Type from JIRA Project [default:
-        Task]
-    -p, --component=<name>  Component name from JIRA Project [default:
-        False]
-    -l, --labels=<labels>   Labels, separated by commas [default: False]
-    -c, --config=<file>     Configuration file [default:
-        /etc/zabbix/zabbix2jira.cfg]
-    -o, --output=<file>     Log output to file [default:
-        /var/log/zabbix2jira.log]
+    -t, --issue-type=<type> Issue Type from JIRA Project
+                            [default: Task]
+    -p, --component=<name>  Component name from JIRA Project
+    -l, --labels=<labels>   Labels, separated by commas
+    -c, --config=<file>     Configuration file
+                            [default: /etc/zabbix/zabbix2jira.cfg]
+    -o, --output=<file>     Log output to file
+                            [default: /var/log/zabbix2jira.log]
     -v, --verbose           Verbose output
     -d, --debug             Debug output
     -q, --quiet             Quiet output


### PR DESCRIPTION
This commit fix 2 bugs:

1. `[default: value]` has to be at the same line. If it doesn't, default value is set as `None`
2. Options which receives a value, such as `-p` and `-l`, are parsed as `string`. Because of this, `False` default value is not parsed as `bool`. This is important for conditions like [this one](https://github.com/Movile/zabbix2jira/blob/master/zabbix2jira/commands/problem.py#L64). For that reason I removed their default values making `None` as default. 
